### PR TITLE
move setuptools<81 to pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,9 @@ Requires [uv](https://docs.astral.sh/uv/getting-started/installation/). Isaac Si
 
 ```bash
 git clone https://github.com/NVlabs/RoboLab.git
-cd robolab
+cd RoboLab
 uv venv --python 3.11
 source .venv/bin/activate
-uv pip install "setuptools<81"
 uv sync
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "tqdm",
     "tyro",
     "python-dotenv",
+    "setuptools<81",
 ]
 
 [project.optional-dependencies]
@@ -55,6 +56,9 @@ no-build-isolation-package = ["flatdict"]
 # wheel — no Linux build — so any resolver pass that picked it would break
 # `uv sync` on Linux. Exclude that specific version.
 constraint-dependencies = ["warp-lang != 1.13.0.dev20260418"]
+
+[tool.uv.extra-build-dependencies]
+flatdict = ["setuptools<81"]
 
 [[tool.uv.index]]
 name = "pytorch-cu128"

--- a/run_apptainer.sh
+++ b/run_apptainer.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+IMAGE="${ROBOLAB_IMAGE:-$SCRIPT_DIR/robolab-isaaclab-2.2.0.sif}"
+REPO="${ROBOLAB_REPO:-$SCRIPT_DIR}"
+VENV="${UV_PROJECT_ENVIRONMENT:-$REPO/.venv}"
+
+if [[ ! -f "$IMAGE" ]]; then
+    echo "Apptainer image not found: $IMAGE" >&2
+    echo "Set ROBOLAB_IMAGE=/path/to/robolab-isaaclab-2.2.0.sif or place it beside this script." >&2
+    exit 1
+fi
+
+export OMNI_KIT_ACCEPT_EULA="${OMNI_KIT_ACCEPT_EULA:-Y}"
+export ACCEPT_EULA="${ACCEPT_EULA:-Y}"
+export UV_PROJECT_ENVIRONMENT="$VENV"
+
+# Use bash -c (not -lc) to skip host .bashrc / conda init.
+# Explicitly activate the venv so uv never falls back to host Python.
+apptainer exec --nv \
+    --bind "$REPO:/workspace/robolab" \
+    --bind /gscratch:/gscratch \
+    --pwd /workspace/robolab \
+    "$IMAGE" \
+    bash -c '
+        export VIRTUAL_ENV="$UV_PROJECT_ENVIRONMENT"
+        export PATH="$VIRTUAL_ENV/bin:/usr/local/bin:$HOME/.local/bin:$PATH"
+        unset CONDA_DEFAULT_ENV CONDA_PREFIX
+        "$@"
+    ' bash "$@"


### PR DESCRIPTION
Move `setuptools<81` from standalone installation to `pyproject.toml`.

Previously, the compilation of `flatdict` ignored the dependency during `uv sync` causing:

```
warning: The `extra-build-dependencies` option is experimental and may change without warning. Pass `--preview-features extra-build-dependencies` to disable this warning.
Resolved 225 packages in 2ms
  × Failed to build `flatdict==4.0.1`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)                                                              

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 11, in <module>
        File "/mmfs1/home/memmelma/projects/robolab/RoboLab/.venv/lib/python3.11/site-packages/setuptools/build_meta.py", line 438, in            
      build_wheel
          return _build(['bdist_wheel'])
                 ^^^^^^^^^^^^^^^^^^^^^^^
        File "/mmfs1/home/memmelma/projects/robolab/RoboLab/.venv/lib/python3.11/site-packages/setuptools/build_meta.py", line 429, in _build     
          return self._build_with_temp_dir(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/mmfs1/home/memmelma/projects/robolab/RoboLab/.venv/lib/python3.11/site-packages/setuptools/build_meta.py", line 410, in            
      _build_with_temp_dir
          self.run_setup()
        File "/mmfs1/home/memmelma/projects/robolab/RoboLab/.venv/lib/python3.11/site-packages/setuptools/build_meta.py", line 520, in run_setup  
          super().run_setup(setup_script=setup_script)
        File "/mmfs1/home/memmelma/projects/robolab/RoboLab/.venv/lib/python3.11/site-packages/setuptools/build_meta.py", line 317, in run_setup  
          exec(code, locals())
        File "<string>", line 1, in <module>
      ModuleNotFoundError: No module named 'pkg_resources'

      hint: This error likely indicates that `flatdict@4.0.1` depends on `pkg_resources`, but doesn't declare it as a build dependency. If        
      `flatdict` is a first-party package, consider adding `pkg_resources` to its `build-system.requires`. Otherwise, either add it to your       
      `pyproject.toml` under:

      [tool.uv.extra-build-dependencies]
      flatdict = ["pkg_resources"]

      or `uv pip install pkg_resources` into the environment and re-run with `--no-build-isolation`.                                              
  help: `flatdict` (v4.0.1) was included because `robolab` (v0.1.0) depends on `isaaclab` (v2.2.0) which depends on `flatdict`    
```

Tested in `docker://nvcr.io/nvidia/isaac-lab:2.2.0`.