### PR TITLE
fix: call EpisodeData.pre_export() before HDF5 write

### DIFF
--- a/robolab/core/logging/recorder_manager.py
+++ b/robolab/core/logging/recorder_manager.py
@@ -414,6 +414,11 @@ class RobolabRecorderManager(RecorderManager):
             # Get episode index for this environment (if set)
             episode_index = self._current_episode_index.get(env_id)
 
+            # Convert list-of-tensor buffers to stacked tensors before writing;
+            # EpisodeData.add() stores values as lists but HDF5 handlers expect
+            # torch.Tensor -- without pre_export(), value.cpu().numpy() crashes
+            self._episodes[env_id].pre_export()
+
             # Append data to the current episode (creates one if not started)
             # If episode_index is set and episode exists, it will be deleted and recreated
             target_handler.append_data(self._episodes[env_id], episode_index=episode_index)
@@ -524,12 +529,14 @@ class RobolabRecorderManager(RecorderManager):
             if is_streaming:
                 # Streaming mode: append any remaining data and finalize
                 if episode and not episode.is_empty():
+                    episode.pre_export()
                     target_handler.append_data(episode, episode_index=episode_index)
                 target_handler.end_episode(success=episode_succeeded, episode_index=episode_index)
                 self._streaming_active[env_id] = False
             else:
                 # Standard mode: write complete episode (with optional episode_index)
                 if episode and not episode.is_empty():
+                    episode.pre_export()
                     if episode_index is not None:
                         target_handler.begin_episode(episode.seed, episode_index=episode_index)
                         target_handler.append_data(episode, episode_index=episode_index)


### PR DESCRIPTION
## Bug

`RobolabRecorderManager` calls `append_data()` / `write_episode()` on `EpisodeData` objects whose internal values are still **lists of tensors** (as stored by `EpisodeData.add()`). HDF5 handlers assume values are `torch.Tensor` and call `value.cpu().numpy()`, which raises `AttributeError: 'list' object has no attribute 'cpu'` on any environment when the episode is exported.

This is a pure upstream bug — it crashes on any RoboLab environment regardless of hardware or Isaac Sim version.

## Root Cause

`EpisodeData.add()` stores each value as `[tensor.clone()]` and appends subsequent values to the list. `EpisodeData.pre_export()` converts these lists to stacked tensors via `torch.stack()`. The upstream Isaac Lab `RecorderManager.export_episodes()` always calls `pre_export()` before `write_episode()`, but RoboLab's `RobolabRecorderManager` overrides `export_episodes()` and adds a `flush_buffer()` method, both of which skip `pre_export()`.

## Fix

Add `episode.pre_export()` before every `append_data()` / `write_episode()` call in `RobolabRecorderManager`:

- `flush_buffer()` — streaming mid-episode flush
- `export_episodes()` streaming branch — episode finalize
- `export_episodes()` standard branch — non-streaming write

`pre_export()` is idempotent (list→tensor is one-way; tensors pass through unchanged), so duplicate calls are safe.

## Testing

9 unit tests verified locally (not committed — RoboLab repo has no existing test infrastructure). All pass:

| Test | Verifies |
|------|----------|
| `test_append_data_without_pre_export_crashes` | Regression: un-exported EpisodeData crashes on write |
| `test_append_data_after_pre_export_succeeds` | Fix: pre_export makes write succeed + data correct |
| `test_pre_export_idempotent` | Calling pre_export twice is safe |
| `test_streaming_lifecycle` | Full streaming lifecycle with multiple flushes |
| `test_nested_keys_round_trip` | Nested keys (obs/policy/term1) survive round-trip |
| `test_write_episode_without_pre_export_crashes` | Non-streaming path also crashes without pre_export |
| `test_write_episode_after_pre_export_succeeds` | Non-streaming path works with pre_export |
| `test_pre_export_cuda_tensors` | CUDA tensors stack correctly |
| `test_streaming_lifecycle_cuda` | CUDA + streaming end-to-end |

Signed-off-by: yingru <yingru@baidu.com>
