### PR TITLE
Fix IsaacLab 5.1 runtime compatibility

### DIFF
--- a/robolab/core/environments/base.py
+++ b/robolab/core/environments/base.py
@@ -162,19 +162,38 @@ class RobolabDefaultEnvCfg(ManagerBasedRLEnvCfg):
         self.sim.use_fabric = True
 
         # PhysX settings
-        self.sim.physx.gpu_temp_buffer_capacity = 2**30
-        self.sim.physx.gpu_heap_capacity = 2**30
-        self.sim.physx.gpu_collision_stack_size = 2**30
-        self.sim.physx.enable_ccd = True
-        self.sim.physx.contact_offset = 0.02
-        self.sim.physx.rest_offset = 0.01
-        self.sim.physx.num_position_iterations = 32
-        self.sim.physx.num_velocity_iterations = 1
-        self.sim.physx.bounce_threshold_velocity = 0.2
-        self.sim.physx.max_depenetration_velocity = 100.0
-        self.sim.physx.solver_type = 1
-        self.sim.physx.num_threads = 4
-        self.sim.physx.relaxation = 0.75
-        self.sim.physx.warm_start = 0.4
-        self.sim.physx.shape_collision_distance = 0.0
-        self.sim.physx.shape_collision_margin = 0.0
+        physx = getattr(self.sim, "physx", None)
+        if physx is None:
+            try:
+                from isaaclab_physx.physics import PhysxCfg
+
+                if self.sim.physics is None:
+                    self.sim.physics = PhysxCfg()
+                physx = self.sim.physics
+            except ImportError:
+                physx = None
+
+        if physx is not None:
+            physx_settings = {
+                "gpu_temp_buffer_capacity": 2**30,
+                "gpu_heap_capacity": 2**30,
+                "gpu_collision_stack_size": 2**30,
+                "enable_ccd": True,
+                "contact_offset": 0.02,
+                "rest_offset": 0.01,
+                "num_position_iterations": 32,
+                "num_velocity_iterations": 1,
+                "max_position_iteration_count": 32,
+                "max_velocity_iteration_count": 1,
+                "bounce_threshold_velocity": 0.2,
+                "max_depenetration_velocity": 100.0,
+                "solver_type": 1,
+                "num_threads": 4,
+                "relaxation": 0.75,
+                "warm_start": 0.4,
+                "shape_collision_distance": 0.0,
+                "shape_collision_margin": 0.0,
+            }
+            for attr_name, attr_value in physx_settings.items():
+                if hasattr(physx, attr_name):
+                    setattr(physx, attr_name, attr_value)

--- a/robolab/core/observations/example.py
+++ b/robolab/core/observations/example.py
@@ -8,6 +8,11 @@ from isaaclab.managers import SceneEntityCfg
 from isaaclab.utils import configclass
 
 
+image_observation = getattr(mdp, "image", None)
+if image_observation is None:
+    image_observation = mdp.observations.image
+
+
 @configclass
 class CameraObservationCfg:
     """Static camera observation configuration - example implementation."""
@@ -15,7 +20,7 @@ class CameraObservationCfg:
     class ImageObsCfg(ObsGroup):
         """Observations for policy."""
         egocentric_wide_angle_camera = ObsTerm(
-            func=mdp.observations.image,
+            func=image_observation,
             params={
                 "sensor_cfg": SceneEntityCfg("egocentric_wide_angle_camera"),
                 "data_type": "rgb",
@@ -24,7 +29,7 @@ class CameraObservationCfg:
             )
 
         egocentric_mirrored_wide_angle_camera = ObsTerm(
-            func=mdp.observations.image,
+            func=image_observation,
             params={
                 "sensor_cfg": SceneEntityCfg("egocentric_mirrored_camera"),
                 "data_type": "rgb",

--- a/robolab/core/observations/observation_utils.py
+++ b/robolab/core/observations/observation_utils.py
@@ -12,6 +12,18 @@ from isaaclab.sensors import CameraCfg
 from isaaclab.utils import configclass
 
 
+def _image_observation_func():
+    image_func = getattr(mdp, "image", None)
+    if image_func is not None:
+        return image_func
+
+    observations = getattr(mdp, "observations", None)
+    image_func = getattr(observations, "image", None) if observations is not None else None
+    if image_func is None:
+        raise AttributeError("IsaacLab image observation function not found")
+    return image_func
+
+
 def generate_image_obs_from_cameras(camera_cfgs: List[Any] | Any):
     """
     Dynamically create an image observation group configuration from one or more camera configs.
@@ -41,6 +53,7 @@ def generate_image_obs_from_cameras(camera_cfgs: List[Any] | Any):
     """
     # Create a dictionary to store observation terms
     obs_terms = {}
+    image_observation = _image_observation_func()
 
     if not isinstance(camera_cfgs, list):
         camera_cfgs = [camera_cfgs]
@@ -59,7 +72,7 @@ def generate_image_obs_from_cameras(camera_cfgs: List[Any] | Any):
                 # if hasattr(attr_value, 'prim_path'):
                     camera_name = attr_name
                     obs_terms[camera_name] = ObsTerm(
-                        func=mdp.observations.image,
+                        func=image_observation,
                         params={
                             "sensor_cfg": SceneEntityCfg(camera_name),
                             "data_type": "rgb",

--- a/robolab/core/world/world_state.py
+++ b/robolab/core/world/world_state.py
@@ -21,7 +21,8 @@ from typing import Any, Callable
 import isaaclab.sim.utils as sim_utils
 import numpy as np
 import torch
-from isaaclab.assets import Articulation, AssetBase, DeformableObject, RigidObject
+from isaaclab.assets import Articulation, AssetBase, RigidObject
+from isaaclab_physx.assets import DeformableObject
 from isaaclab.envs import ManagerBasedRLEnv
 from isaaclab.sensors.frame_transformer.frame_transformer import FrameTransformer
 from isaaclab.utils.math import transform_points

--- a/robolab/robots/droid.py
+++ b/robolab/robots/droid.py
@@ -7,6 +7,7 @@ import isaaclab.envs.mdp as mdp
 import isaaclab.sim as sim_utils
 import numpy as np
 import torch
+import warp as wp
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets import ArticulationCfg
 from isaaclab.controllers.differential_ik_cfg import DifferentialIKControllerCfg
@@ -175,6 +176,12 @@ contact_gripper = {"gripper": "{ENV_REGEX_NS}/robot/Gripper/Robotiq_2F_85/left_i
 ########################################################
 
 
+def _to_torch(value):
+    if isinstance(value, torch.Tensor):
+        return value
+    return wp.to_torch(value)
+
+
 def arm_joint_pos(
     env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")
 ):
@@ -192,7 +199,7 @@ def arm_joint_pos(
     joint_indices = [
         i for i, name in enumerate(robot.data.joint_names) if name in joint_names
     ]
-    joint_pos = robot.data.joint_pos[:, joint_indices]
+    joint_pos = _to_torch(robot.data.joint_pos)[:, joint_indices]
     return joint_pos
 
 
@@ -206,7 +213,7 @@ def gripper_pos(
     joint_indices = [
         i for i, name in enumerate(robot.data.joint_names) if name in joint_names
     ]
-    joint_pos = robot.data.joint_pos[:, joint_indices]
+    joint_pos = _to_torch(robot.data.joint_pos)[:, joint_indices]
 
     # rescale
     joint_pos = joint_pos / (np.pi / 4)
@@ -223,7 +230,7 @@ def ee_pos(
     ee_body_name = "base_link"  # Robotiq gripper base link
     body_idx = robot.data.body_names.index(ee_body_name)
     # Return position (shape: [num_envs, 3])
-    return robot.data.body_pos_w[:, body_idx, :] - env.scene.env_origins[:, 0:3]
+    return _to_torch(robot.data.body_pos_w)[:, body_idx, :] - env.scene.env_origins[:, 0:3]
 
 
 def ee_quat(
@@ -235,21 +242,21 @@ def ee_quat(
     ee_body_name = "base_link"  # Robotiq gripper base link
     body_idx = robot.data.body_names.index(ee_body_name)
     # Return quaternion (shape: [num_envs, 4])
-    return robot.data.body_quat_w[:, body_idx, :]
+    return _to_torch(robot.data.body_quat_w)[:, body_idx, :]
 
 
 def eef_pos(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg("frames")):
     """Returns the eef_frame position (x, y, z) in the env-local frame."""
     frames = env.scene[asset_cfg.name]
     idx = frames.data.target_frame_names.index("eef_frame")
-    return frames.data.target_pos_w[:, idx, :] - env.scene.env_origins[:, 0:3]
+    return _to_torch(frames.data.target_pos_w)[:, idx, :] - env.scene.env_origins[:, 0:3]
 
 
 def eef_quat(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg("frames")):
     """Returns the eef_frame orientation as quaternion (w, x, y, z) in the world frame."""
     frames = env.scene[asset_cfg.name]
     idx = frames.data.target_frame_names.index("eef_frame")
-    return frames.data.target_quat_w[:, idx, :]
+    return _to_torch(frames.data.target_quat_w)[:, idx, :]
 
 ########################################################
 # Actions


### PR DESCRIPTION
This patch updates RoboLab to run on the current IsaacLab / Isaac Sim stack used by AgenticSim.\n\nChanges:\n- Imports DeformableObject from isaaclab_physx.\n- Adds image observation fallback compatibility.\n- Bridges legacy PhysX config fields to PhysxCfg when needed.\n- Converts warp-backed robot and frame data to torch before indexing.\n\nValidated by creating and resetting BananaInBowlTask-v0.