### PR TITLE
Updated Cosmos3 client to work with vllm-omni server

### DIFF
--- a/policies/cosmos3/README.md
+++ b/policies/cosmos3/README.md
@@ -2,7 +2,7 @@
 
 [**Cosmos 3**](https://huggingface.co/collections/nvidia/cosmos3) is a suite of omnimodal world models designed to jointly process and generate language, images, video, audio, and action sequences. This directory provides the RoboLab client for [**Cosmos3-Nano-Policy-DROID**](https://huggingface.co/nvidia/Cosmos3-Nano-Policy-DROID), a World-Action Model (WAM) obtained by post-training Cosmos 3 on the [DROID](https://droid-dataset.github.io/) dataset.
 
-[`client.py`](./client.py) provides the `Cosmos3Client` class that connects to a policy server hosting Cosmos3-Nano-Policy-DROID over the OpenPI WebSocket protocol. `Cosmos3Client` requires the [`openpi-client`](https://github.com/Physical-Intelligence/openpi/tree/main/packages/openpi-client) package.
+[`client.py`](./client.py) provides the `Cosmos3Client` class that connects to a policy server hosting Cosmos3-Nano-Policy-DROID over the OpenPI WebSocket protocol. The client uses RoboLab's shared MsgPack/NumPy WebSocket transport, including optional Bearer authentication, and does not depend on `openpi-client`.
 
 Below is a quickstart for bringing up the policy server and running an evaluation from a RoboLab client.
 
@@ -83,6 +83,31 @@ Run a task against the policy server. This opens a viewer window for real-time v
 python policies/cosmos3/run.py \
   --task BananaInBowlTask
 ```
+
+The host and port form above targets the Cosmos reference server at
+`ws://localhost:8000`. To use a routed endpoint such as vLLM-Omni's standard
+OpenPI endpoint, pass the complete URI:
+
+```Shell
+python policies/cosmos3/run.py \
+  --remote-uri ws://localhost:8000/v1/realtime/robot/openpi \
+  --task BananaInBowlTask
+```
+
+If the server was started with API-key authentication, pass the key as a
+Bearer token with `--remote-token`, or set `COSMOS3_API_TOKEN`. The command-line
+value takes precedence over the environment variable:
+
+```Shell
+export COSMOS3_API_TOKEN=<your_api_key>
+python policies/cosmos3/run.py \
+  --remote-uri wss://policy.example/v1/realtime/robot/openpi \
+  --task BananaInBowlTask
+```
+
+RoboLab sends a distinct `session_id` for every episode and parallel
+environment. The VoLo Cosmos3 client sends that policy-session identifier as
+well as VoLo's separate `__episode_id`; proxies should preserve both fields.
 
 To evaluate across multiple sub-environments in parallel in headless mode:
 

--- a/policies/cosmos3/client.py
+++ b/policies/cosmos3/client.py
@@ -2,13 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import os
+
 import numpy as np
 import torch
 import torch.nn.functional as F
 
-from openpi_client import image_tools, websocket_client_policy
-
+from robolab.core.utils.image_utils import resize_with_pad
 from robolab.eval.base_client import InferenceClient
+from robolab.eval.websocket_transport import MsgPackWebSocketTransport
 
 logger = logging.getLogger(__name__)
 
@@ -20,33 +22,44 @@ class Cosmos3Client(InferenceClient):
     IMAGE_H = 360
     OPEN_LOOP_HORIZON = 32
 
-    def __init__(self, remote_host: str = "localhost", remote_port: int = 8000):
+    def __init__(
+        self,
+        remote_host: str = "localhost",
+        remote_port: int = 8000,
+        remote_uri: str | None = None,
+        api_token: str | None = None,
+    ) -> None:
         """ """
         super().__init__()
         self._remote_host = remote_host
         self._remote_port = remote_port
+        self._remote_uri = remote_uri
+        self._api_token = api_token or os.environ.get("COSMOS3_API_TOKEN")
+        self._uri = remote_uri if remote_uri is not None else f"ws://{remote_host}:{remote_port}"
 
         self._image_w = self.IMAGE_W
         self._image_h = self.IMAGE_H
 
         self.open_loop_horizon = self.OPEN_LOOP_HORIZON
 
-        display = f"{self._remote_host}:{self._remote_port}"
+        display = self._uri
         print(f"[{self.__class__.__name__}] Awaiting for server on {display} to be ready...")
         self.client = self._connect()
         print(f"[{self.__class__.__name__}] Connected to {display}.")
 
-    def _connect(self) -> websocket_client_policy.WebsocketClientPolicy:
+    def _connect(self) -> MsgPackWebSocketTransport:
         """ """
-        return websocket_client_policy.WebsocketClientPolicy(self._remote_host, self._remote_port)
+        transport = MsgPackWebSocketTransport(self._uri, api_token=self._api_token)
+        transport.connect()
+        return transport
 
-    def _infer_with_retry(self, request: dict, max_retries: int = 3) -> dict:
+    def _infer_with_retry(self, request: dict, max_retries: int = 3) -> object:
         """ """
         import websockets.exceptions
 
         for attempt in range(max_retries):
             try:
-                return self.client.infer(request)
+                return self.client.request(request)
             except (
                 websockets.exceptions.ConnectionClosedError,
                 websockets.exceptions.ConnectionClosedOK,
@@ -61,6 +74,10 @@ class Cosmos3Client(InferenceClient):
                     attempt + 1,
                     max_retries,
                 )
+                try:
+                    self.client.close()
+                except Exception:
+                    pass
                 self.client = self._connect()
                 # Flush chunk cache so all envs re-request on next step.
                 self._chunks.clear()
@@ -69,11 +86,11 @@ class Cosmos3Client(InferenceClient):
     def _extract_observation(self, raw_obs: dict, *, env_id: int = 0) -> dict:
         """ """
         left_image = raw_obs["image_obs"]["over_shoulder_left_camera"][env_id].cpu().numpy()
-        left_image = image_tools.resize_with_pad(left_image, self._image_h, self._image_w)
+        left_image = resize_with_pad(left_image, self._image_h, self._image_w)
         right_image = raw_obs["image_obs"]["over_shoulder_right_camera"][env_id].cpu().numpy()
-        right_image = image_tools.resize_with_pad(right_image, self._image_h, self._image_w)
+        right_image = resize_with_pad(right_image, self._image_h, self._image_w)
         wrist_image = raw_obs["image_obs"]["wrist_cam"][env_id].cpu().numpy()
-        wrist_image = image_tools.resize_with_pad(wrist_image, self._image_h, self._image_w)
+        wrist_image = resize_with_pad(wrist_image, self._image_h, self._image_w)
 
         joint_position = raw_obs["proprio_obs"]["arm_joint_pos"][env_id].cpu().numpy()
         gripper_position = raw_obs["proprio_obs"]["gripper_pos"][env_id].cpu().numpy()
@@ -84,6 +101,10 @@ class Cosmos3Client(InferenceClient):
             "wrist_image": wrist_image,
             "joint_position": joint_position,
             "gripper_position": gripper_position,
+            # ``begin_episode`` receives the run index, while one run may fan
+            # out over several envs. Include both so parallel envs never share
+            # a policy session identifier.
+            "session_id": f"robolab-episode-{self._eval_episode_idx}-env-{env_id}",
         }
 
     def _pack_request(self, extracted_obs: dict, instruction: str) -> dict:
@@ -104,15 +125,31 @@ class Cosmos3Client(InferenceClient):
             "observation/joint_position": extracted_obs["joint_position"],
             "observation/gripper_position": extracted_obs["gripper_position"],
             "prompt": instruction,
+            "session_id": extracted_obs["session_id"],
         }
 
-    def _query_server(self, request: dict) -> dict:
+    def _query_server(self, request: dict) -> object:
         """ """
         return self._infer_with_retry(request)
 
-    def _unpack_response(self, response: dict) -> np.ndarray:
-        """ """
-        return np.asarray(response["action"])
+    def _unpack_response(self, response: object) -> np.ndarray:
+        """Accept Cosmos reference, vLLM-Omni, and proxy action replies."""
+        if isinstance(response, dict):
+            if response.get("type") == "error":
+                raise RuntimeError(str(response.get("message") or "Policy inference failed"))
+            if "action" in response:
+                response = response["action"]
+            elif "actions" in response:
+                response = response["actions"]
+            else:
+                raise RuntimeError("Policy response did not contain 'action' or 'actions'")
+        return np.asarray(response)
+
+    def close(self) -> None:
+        try:
+            self.client.close()
+        except Exception:
+            pass
 
     def _postprocess_chunk(self, chunk: np.ndarray) -> np.ndarray:
         """ """

--- a/policies/cosmos3/run.py
+++ b/policies/cosmos3/run.py
@@ -19,6 +19,22 @@ parser.add_argument(
 parser.add_argument(
     "--remote-port", default=8000, type=int, help="Remote port for policy server (default: 8000)."
 )
+parser.add_argument(
+    "--remote-uri",
+    "--remote_uri",
+    default=None,
+    help=(
+        "Full WebSocket URI for the policy server, for example "
+        "ws://localhost:8000/v1/realtime/robot/openpi. "
+        "Overrides --remote-host and --remote-port when set."
+    ),
+)
+parser.add_argument(
+    "--remote-token",
+    "--remote_token",
+    default=None,
+    help="Bearer token for the remote server. Falls back to COSMOS3_API_TOKEN.",
+)
 
 from robolab.eval.runner import add_common_eval_args, run_evaluation
 
@@ -40,7 +56,12 @@ auto_register_droid_envs(task=args_cli.task, cameras=WRIST_LEFT_RIGHT_HEAD)
 
 def make_client(args: argparse.Namespace) -> Cosmos3Client:
     """ """
-    return Cosmos3Client(remote_host=args.remote_host, remote_port=args.remote_port)
+    return Cosmos3Client(
+        remote_host=args.remote_host,
+        remote_port=args.remote_port,
+        remote_uri=args.remote_uri,
+        api_token=args.remote_token,
+    )
 
 
 def main() -> None:

--- a/policies/dreamzero/client.py
+++ b/policies/dreamzero/client.py
@@ -24,9 +24,9 @@ import time
 import uuid
 
 import numpy as np
-import websockets.sync.client
 
 from robolab.eval.base_client import InferenceClient
+from robolab.eval.websocket_transport import MsgPackWebSocketTransport
 
 logger = logging.getLogger(__name__)
 
@@ -40,51 +40,6 @@ RECV_TIMEOUT_SECS = 300
 MAX_CONNECT_RETRIES = 5
 MAX_INFER_RETRIES = 3
 RETRY_BACKOFF_BASE_SECS = 2
-
-
-class MsgPackNumpy:
-    """Simple msgpack wrapper with numpy support.
-
-    Mirrors the client_lib.msgpack_numpy from dreamzero.
-    """
-
-    def __init__(self):
-        import msgpack
-        self._msgpack = msgpack
-
-    def pack(self, obj):
-        # Don't use strict_types=True - it breaks tuple serialization
-        return self._msgpack.packb(obj, default=self._encode_numpy)
-
-    def unpack(self, data):
-        return self._msgpack.unpackb(data, object_hook=self._decode_numpy, strict_map_key=False)
-
-    def _encode_numpy(self, obj):
-        if isinstance(obj, np.ndarray):
-            if obj.dtype.kind in ("V", "O", "c"):
-                raise ValueError(f"Unsupported dtype: {obj.dtype}")
-            return {
-                b"__ndarray__": True,
-                b"data": obj.tobytes(),
-                b"dtype": obj.dtype.str,
-                b"shape": obj.shape,
-            }
-
-        if isinstance(obj, np.generic):
-            return {
-                b"__npgeneric__": True,
-                b"data": obj.item(),
-                b"dtype": obj.dtype.str,
-            }
-
-        return obj
-
-    def _decode_numpy(self, obj):
-        if b"__ndarray__" in obj:
-            return np.ndarray(buffer=obj[b"data"], dtype=np.dtype(obj[b"dtype"]), shape=obj[b"shape"])
-        if b"__npgeneric__" in obj:
-            return np.dtype(obj[b"dtype"]).type(obj[b"data"])
-        return obj
 
 
 class DreamZeroClient(InferenceClient):
@@ -105,8 +60,8 @@ class DreamZeroClient(InferenceClient):
         open_loop_horizon: int = 24,
         image_height: int = 180,
         image_width: int = 320,
-        remote_uri: str = None,
-        api_token: str = None,
+        remote_uri: str | None = None,
+        api_token: str | None = None,
         binarize_gripper: bool = False,
         resize: str = "area",
         cam2_source: str = "black",
@@ -121,20 +76,27 @@ class DreamZeroClient(InferenceClient):
         self.resize = resize
         self.cam2_source = cam2_source
 
-        # Auth: explicit param takes priority, then env var, then no auth
+        # Auth: explicit param takes priority, then env var, then no auth.
         token = api_token or os.environ.get("DREAMZERO_API_TOKEN")
-        self._auth_headers = {"Authorization": f"Bearer {token}"} if token else {}
 
         # Per-env session IDs. The server uses session_id to track temporal
         # history; parallel envs must not share one or their histories get mixed.
         self._env_session_id: dict[int, str] = {}
 
-        # MsgPack for numpy serialization
-        self._packer = MsgPackNumpy()
-
-        # Connect to server
+        # Connect to the server through the shared wire transport. Retry and
+        # session invalidation remain DreamZero-specific below.
         self._uri = remote_uri if remote_uri is not None else f"ws://{remote_host}:{remote_port}"
-        self._ws = None
+        self._transport = MsgPackWebSocketTransport(
+            self._uri,
+            api_token=token,
+            connect_kwargs={
+                "open_timeout": CONNECT_TIMEOUT_SECS,
+                "ping_interval": PING_INTERVAL_SECS,
+                "ping_timeout": PING_TIMEOUT_SECS,
+            },
+            metadata_timeout=RECV_TIMEOUT_SECS,
+        )
+        self._packer = self._transport.packer
         self._connect_with_retries()
 
     # ---- required hooks -----------------------------------------------
@@ -244,12 +206,10 @@ class DreamZeroClient(InferenceClient):
         print(f"[{self.__class__.__name__}] Reset complete (env_id={env_id}).")
 
     def close(self) -> None:
-        if self._ws is not None:
-            try:
-                self._ws.close()
-            except Exception:
-                pass
-            self._ws = None
+        try:
+            self._transport.close()
+        except Exception:
+            pass
 
     # ---- connection internals -----------------------------------------
 
@@ -278,40 +238,16 @@ class DreamZeroClient(InferenceClient):
             if attempt > 1:
                 print(f"{tag} Connection attempt {attempt}/{MAX_CONNECT_RETRIES}...")
             try:
-                try:
-                    self._ws = websockets.sync.client.connect(
-                        self._uri,
-                        additional_headers=self._auth_headers,
-                        compression=None,
-                        max_size=None,
-                        open_timeout=CONNECT_TIMEOUT_SECS,
-                        ping_interval=PING_INTERVAL_SECS,
-                        ping_timeout=PING_TIMEOUT_SECS,
-                    )
-                except TypeError:
-                    # Older websockets (e.g. 11.x bundled with Isaac Sim) lacks ping_interval/ping_timeout
-                    self._ws = websockets.sync.client.connect(
-                        self._uri,
-                        additional_headers=self._auth_headers,
-                        compression=None,
-                        max_size=None,
-                        open_timeout=CONNECT_TIMEOUT_SECS,
-                    )
-
-                self._server_metadata = self._packer.unpack(
-                    self._ws.recv(timeout=RECV_TIMEOUT_SECS)
-                )
+                self._server_metadata = self._transport.connect()
                 print(f"{tag} Server metadata: {self._server_metadata}")
                 print(f"{tag} Connected successfully.")
                 return
 
             except Exception as e:
-                if self._ws is not None:
-                    try:
-                        self._ws.close()
-                    except Exception:
-                        pass
-                    self._ws = None
+                try:
+                    self._transport.close()
+                except Exception:
+                    pass
 
                 if attempt == MAX_CONNECT_RETRIES:
                     raise ConnectionError(
@@ -329,11 +265,8 @@ class DreamZeroClient(InferenceClient):
 
     def _ensure_connected(self):
         """Reconnect if the WebSocket has been closed or lost."""
-        try:
-            if self._ws is not None and self._ws.socket is not None:
-                return
-        except Exception:
-            pass
+        if self._transport.connected:
+            return
         tag = f"[{self.__class__.__name__}]"
         print(f"{tag} Connection lost. Reconnecting...")
         self._connect_with_retries()
@@ -354,17 +287,13 @@ class DreamZeroClient(InferenceClient):
                 print(f"{tag} send/recv attempt {attempt}/{MAX_INFER_RETRIES}...")
             try:
                 self._ensure_connected()
-                assert self._ws is not None
-                self._ws.send(data)
-                return self._ws.recv(timeout=timeout)
+                return self._transport.send_recv(data, timeout=timeout)
             except Exception as e:
                 last_exc = e
-                if self._ws is not None:
-                    try:
-                        self._ws.close()
-                    except Exception:
-                        pass
-                    self._ws = None
+                try:
+                    self._transport.close()
+                except Exception:
+                    pass
 
                 if attempt == MAX_INFER_RETRIES:
                     break

--- a/policies/volo/README.md
+++ b/policies/volo/README.md
@@ -16,8 +16,13 @@ python policies/volo/run.py \
 
 The runner supports `cosmos3` and the Pi0-family policies. See the [policies README](../README.md) for shared evaluation options.
 
+`--remote-uri` is available for every backend and overrides `--remote-host`
+and `--remote-port`. For an authenticated Cosmos3 endpoint, use
+`--remote-token` or the `COSMOS3_API_TOKEN` environment variable; this token
+option does not apply to the Pi0-family client.
+
 ## How the proxy backend works
 
-The VoLo clients wrap existing backends (cosmos3, pi0 family — selected via `--policy`) for use behind a VoLo inference proxy. They compose `OrchestratorMetadataMixin` ([`metadata.py`](./metadata.py)) over the backend client, producing a request that is a strict superset of the backend's wire format: depth images, camera calibration, front RGB, an `__episode_id`, and (with `--enable-gt-state`) simulator ground-truth state with client-side lift tracking and grasp detection derived from the raw per-step snapshot.
+The VoLo clients wrap existing backends (cosmos3, pi0 family — selected via `--policy`) for use behind a VoLo inference proxy. They compose `OrchestratorMetadataMixin` ([`metadata.py`](./metadata.py)) over the backend client, producing a request that is a strict superset of the backend's wire format: depth images, camera calibration, front RGB, an `__episode_id`, and (with `--enable-gt-state`) simulator ground-truth state with client-side lift tracking and grasp detection derived from the raw per-step snapshot. Cosmos3 requests also retain the backend's per-environment `session_id`; it identifies policy state, while `__episode_id` identifies the VoLo orchestration episode. Proxies should forward both without treating them as aliases.
 
 The runner registers environments via [`registration.py`](./registration.py), which turns on depth rendering plus `<camera>_depth` and `<camera>_pos/_quat/_K` observation terms, and adds the `robovolo` content-pack folder to task discovery; standard backends never pay that cost.

--- a/policies/volo/run.py
+++ b/policies/volo/run.py
@@ -28,7 +28,10 @@ parser.add_argument("--remote-port", "--remote_port", type=int, default=8000,
                     help="Remote port for the proxy/policy server (default: 8000).")
 parser.add_argument("--remote-uri", "--remote_uri", type=str, default=None,
                     help=("Full WebSocket URI for the proxy/policy server, e.g. wss://host.lepton.run. "
-                          "Overrides --remote-host and --remote-port when set. Pi0-family backends only."))
+                          "Overrides --remote-host and --remote-port when set."))
+parser.add_argument("--remote-token", "--remote_token", type=str, default=None,
+                    help=("Bearer token for an authenticated Cosmos3 proxy/policy server. "
+                          "Falls back to COSMOS3_API_TOKEN. Cosmos3 backend only."))
 parser.add_argument("--open-loop-horizon", "--open_loop_horizon", type=int, default=None,
                     help=("Number of actions to execute from each predicted chunk before requesting a "
                           "new one. If omitted, the backend client uses its default. "
@@ -68,7 +71,12 @@ def make_client(args: argparse.Namespace):
     if args.policy == "cosmos3":
         from policies.volo.client import VoloCosmos3Client
 
-        return VoloCosmos3Client(remote_host=args.remote_host, remote_port=args.remote_port)
+        return VoloCosmos3Client(
+            remote_host=args.remote_host,
+            remote_port=args.remote_port,
+            remote_uri=args.remote_uri,
+            api_token=args.remote_token,
+        )
 
     from policies.volo.client import VoloPi0Client
 

--- a/robolab/eval/websocket_transport.py
+++ b/robolab/eval/websocket_transport.py
@@ -114,11 +114,25 @@ class MsgPackWebSocketTransport:
             if isinstance(raw_metadata, str):
                 raise RuntimeError(f"Policy server returned text metadata: {raw_metadata}")
             self.server_metadata = self.packer.unpack(raw_metadata)
+            if isinstance(self.server_metadata, dict) and self.server_metadata.get("type") == "error":
+                message = self.server_metadata.get("message") or self.server_metadata.get("error")
+                raise RuntimeError(f"Policy server rejected the metadata handshake: {message}")
             return self.server_metadata
-        except Exception:
+        except Exception as exc:
             try:
                 self.close()
             except Exception:
+                pass
+            try:
+                from websockets.exceptions import ConnectionClosed
+
+                if isinstance(exc, ConnectionClosed):
+                    raise ConnectionError(
+                        "Policy WebSocket closed before sending its metadata handshake. "
+                        "Verify the URI and Bearer token, confirm that policy serving is enabled, "
+                        "and inspect the server log for its rejection reason."
+                    ) from exc
+            except ImportError:
                 pass
             raise
 

--- a/robolab/eval/websocket_transport.py
+++ b/robolab/eval/websocket_transport.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared synchronous MsgPack/NumPy WebSocket transport for policy clients.
+
+The transport owns only the wire-level behavior shared by policy backends:
+NumPy-aware MsgPack encoding, an initial metadata handshake, optional Bearer
+authentication, and one request/response exchange. Backend clients retain
+their own retry, timeout, and session-lifecycle policies.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import websockets.sync.client
+
+
+class MsgPackNumpy:
+    """Small MsgPack wrapper compatible with OpenPI NumPy markers."""
+
+    def __init__(self) -> None:
+        import msgpack
+
+        self._msgpack = msgpack
+
+    def pack(self, obj: Any) -> bytes:
+        # strict_types=True rejects tuples, which are valid in metadata.
+        return self._msgpack.packb(obj, default=self._encode_numpy)
+
+    def unpack(self, data: bytes) -> Any:
+        return self._msgpack.unpackb(data, object_hook=self._decode_numpy, strict_map_key=False)
+
+    @staticmethod
+    def _encode_numpy(obj: Any) -> Any:
+        if isinstance(obj, np.ndarray):
+            if obj.dtype.kind in ("V", "O", "c"):
+                raise ValueError(f"Unsupported dtype: {obj.dtype}")
+            if not obj.flags.c_contiguous:
+                obj = np.ascontiguousarray(obj)
+            return {
+                b"__ndarray__": True,
+                b"data": obj.tobytes(),
+                b"dtype": obj.dtype.str,
+                b"shape": obj.shape,
+            }
+
+        if isinstance(obj, np.generic):
+            return {
+                b"__npgeneric__": True,
+                b"data": obj.item(),
+                b"dtype": obj.dtype.str,
+            }
+
+        raise TypeError(f"Unsupported type: {type(obj)!r}")
+
+    @staticmethod
+    def _decode_numpy(obj: dict[Any, Any]) -> Any:
+        if b"__ndarray__" in obj:
+            array = np.frombuffer(obj[b"data"], dtype=np.dtype(obj[b"dtype"])).copy()
+            return array.reshape(tuple(obj[b"shape"]))
+        if b"__npgeneric__" in obj:
+            return np.dtype(obj[b"dtype"]).type(obj[b"data"])
+        return obj
+
+
+class MsgPackWebSocketTransport:
+    """Synchronous policy transport with metadata handshake and Bearer auth."""
+
+    def __init__(
+        self,
+        uri: str,
+        *,
+        api_token: str | None = None,
+        connect_kwargs: dict[str, Any] | None = None,
+        metadata_timeout: float | None = None,
+    ) -> None:
+        self.uri = uri
+        self.packer = MsgPackNumpy()
+        self.server_metadata: Any = None
+        self._auth_headers = {"Authorization": f"Bearer {api_token}"} if api_token else {}
+        self._connect_kwargs = {
+            "compression": None,
+            "max_size": None,
+            **(connect_kwargs or {}),
+        }
+        self._metadata_timeout = metadata_timeout
+        self._ws: Any = None
+
+    @property
+    def connected(self) -> bool:
+        try:
+            return self._ws is not None and self._ws.socket is not None
+        except Exception:
+            return False
+
+    def connect(self) -> Any:
+        """Connect and consume the server's first binary metadata message."""
+        kwargs = dict(self._connect_kwargs)
+        kwargs["additional_headers"] = self._auth_headers
+        try:
+            self._ws = websockets.sync.client.connect(self.uri, **kwargs)
+        except TypeError:
+            # Older websockets releases bundled with some Isaac Sim versions
+            # do not expose the sync-client ping tuning arguments.
+            fallback_kwargs = dict(kwargs)
+            fallback_kwargs.pop("ping_interval", None)
+            fallback_kwargs.pop("ping_timeout", None)
+            self._ws = websockets.sync.client.connect(self.uri, **fallback_kwargs)
+
+        try:
+            raw_metadata = self._recv(timeout=self._metadata_timeout)
+            if isinstance(raw_metadata, str):
+                raise RuntimeError(f"Policy server returned text metadata: {raw_metadata}")
+            self.server_metadata = self.packer.unpack(raw_metadata)
+            return self.server_metadata
+        except Exception:
+            try:
+                self.close()
+            except Exception:
+                pass
+            raise
+
+    def send_recv(self, data: bytes, *, timeout: float | None = None) -> bytes | str:
+        if self._ws is None:
+            raise ConnectionError("Policy WebSocket is not connected")
+        self._ws.send(data)
+        return self._recv(timeout=timeout)
+
+    def request(self, request: Any, *, timeout: float | None = None) -> Any:
+        raw = self.send_recv(self.packer.pack(request), timeout=timeout)
+        if isinstance(raw, str):
+            raise RuntimeError(f"Policy server returned a text error:\n{raw}")
+        return self.packer.unpack(raw)
+
+    def close(self) -> None:
+        if self._ws is not None:
+            try:
+                self._ws.close()
+            finally:
+                self._ws = None
+
+    def _recv(self, *, timeout: float | None) -> bytes | str:
+        if timeout is None:
+            return self._ws.recv()
+        return self._ws.recv(timeout=timeout)

--- a/tests/test_cosmos3_client.py
+++ b/tests/test_cosmos3_client.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from policies.cosmos3.client import Cosmos3Client
+from robolab.eval.base_client import InferenceClient
+
+
+class _Tensor:
+    def __init__(self, value):
+        self.value = np.asarray(value)
+
+    def __getitem__(self, index):
+        return _Tensor(self.value[index])
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return self.value
+
+
+class _Transport:
+    def __init__(self, responses=()):
+        self.responses = list(responses)
+        self.requests = []
+        self.closed = False
+
+    def request(self, request):
+        self.requests.append(request)
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    def close(self):
+        self.closed = True
+
+
+def _client_without_connection() -> Cosmos3Client:
+    client = Cosmos3Client.__new__(Cosmos3Client)
+    InferenceClient.__init__(client)
+    client._image_h = 2
+    client._image_w = 2
+    return client
+
+
+def test_constructor_remote_uri_and_explicit_token_take_precedence(monkeypatch):
+    transport = _Transport()
+    monkeypatch.setenv("COSMOS3_API_TOKEN", "environment-token")
+    monkeypatch.setattr(Cosmos3Client, "_connect", lambda _self: transport)
+
+    client = Cosmos3Client(
+        remote_host="ignored-host",
+        remote_port=9999,
+        remote_uri="wss://policy.example/v1/realtime/robot/openpi",
+        api_token="explicit-token",
+    )
+
+    assert client._uri == "wss://policy.example/v1/realtime/robot/openpi"
+    assert client._api_token == "explicit-token"
+    assert client.client is transport
+
+
+def test_constructor_uses_host_port_and_environment_token(monkeypatch):
+    monkeypatch.setenv("COSMOS3_API_TOKEN", "environment-token")
+    monkeypatch.setattr(Cosmos3Client, "_connect", lambda _self: _Transport())
+
+    client = Cosmos3Client(remote_host="policy-host", remote_port=8123)
+
+    assert client._uri == "ws://policy-host:8123"
+    assert client._api_token == "environment-token"
+
+
+def test_parallel_environments_receive_distinct_stable_session_ids():
+    client = _client_without_connection()
+    client.begin_episode(4)
+    images = np.zeros((2, 2, 2, 3), dtype=np.uint8)
+    raw_obs = {
+        "image_obs": {
+            "over_shoulder_left_camera": _Tensor(images),
+            "over_shoulder_right_camera": _Tensor(images),
+            "wrist_cam": _Tensor(images),
+        },
+        "proprio_obs": {
+            "arm_joint_pos": _Tensor(np.zeros((2, 7), dtype=np.float32)),
+            "gripper_pos": _Tensor(np.zeros((2, 1), dtype=np.float32)),
+        },
+    }
+
+    env0 = client._extract_observation(raw_obs, env_id=0)
+    env1 = client._extract_observation(raw_obs, env_id=1)
+
+    assert env0["session_id"] == "robolab-episode-4-env-0"
+    assert env1["session_id"] == "robolab-episode-4-env-1"
+    assert client._pack_request(env0, "pick")["session_id"] == env0["session_id"]
+
+    client.begin_episode(5)
+    assert client._extract_observation(raw_obs, env_id=0)["session_id"] == "robolab-episode-5-env-0"
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        np.asarray([[1.0, 2.0]], dtype=np.float32),
+        {"action": np.asarray([[1.0, 2.0]], dtype=np.float32)},
+        {"actions": np.asarray([[1.0, 2.0]], dtype=np.float32)},
+    ],
+)
+def test_unpack_response_accepts_supported_shapes(response):
+    client = _client_without_connection()
+
+    np.testing.assert_array_equal(
+        client._unpack_response(response),
+        np.asarray([[1.0, 2.0]], dtype=np.float32),
+    )
+
+
+def test_unpack_response_reports_server_error():
+    client = _client_without_connection()
+
+    with pytest.raises(RuntimeError, match="model failed"):
+        client._unpack_response({"type": "error", "message": "model failed"})
+
+
+def test_unpack_response_rejects_unknown_mapping():
+    client = _client_without_connection()
+
+    with pytest.raises(RuntimeError, match="did not contain"):
+        client._unpack_response({"video": b"unused"})
+
+
+def test_infer_retry_reconnects_with_existing_configuration_and_clears_chunks(monkeypatch):
+    client = _client_without_connection()
+    first = _Transport([OSError("connection lost")])
+    second = _Transport([np.asarray([[0.0]], dtype=np.float32)])
+    client.client = first
+    client._chunks[0] = np.asarray([[1.0]])
+    client._counters[0] = 1
+    monkeypatch.setattr(client, "_connect", lambda: second)
+
+    response = client._infer_with_retry({"prompt": "pick"})
+
+    np.testing.assert_array_equal(response, np.asarray([[0.0]], dtype=np.float32))
+    assert first.closed is True
+    assert client.client is second
+    assert client._chunks == {}
+    assert client._counters == {}

--- a/tests/test_dreamzero_transport.py
+++ b/tests/test_dreamzero_transport.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from policies.dreamzero import client as dreamzero_client
+
+
+class _FakeTransport:
+    def __init__(self, uri, **kwargs):
+        self.uri = uri
+        self.kwargs = kwargs
+        self.packer = object()
+
+
+def test_dreamzero_reuses_shared_transport_and_environment_token(monkeypatch):
+    created = []
+
+    def make_transport(uri, **kwargs):
+        transport = _FakeTransport(uri, **kwargs)
+        created.append(transport)
+        return transport
+
+    monkeypatch.setenv("DREAMZERO_API_TOKEN", "environment-token")
+    monkeypatch.setattr(dreamzero_client, "MsgPackWebSocketTransport", make_transport)
+    monkeypatch.setattr(dreamzero_client.DreamZeroClient, "_connect_with_retries", lambda _self: None)
+
+    client = dreamzero_client.DreamZeroClient(
+        remote_uri="wss://dreamzero.example/policy",
+        api_token=None,
+    )
+
+    assert client._transport is created[0]
+    assert created[0].uri == "wss://dreamzero.example/policy"
+    assert created[0].kwargs == {
+        "api_token": "environment-token",
+        "connect_kwargs": {
+            "open_timeout": dreamzero_client.CONNECT_TIMEOUT_SECS,
+            "ping_interval": dreamzero_client.PING_INTERVAL_SECS,
+            "ping_timeout": dreamzero_client.PING_TIMEOUT_SECS,
+        },
+        "metadata_timeout": dreamzero_client.RECV_TIMEOUT_SECS,
+    }

--- a/tests/test_volo_interop.py
+++ b/tests/test_volo_interop.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import numpy as np
 
+from policies.volo.client import VoloCosmos3Client
 from policies.volo.metadata import OrchestratorMetadataMixin
 from robolab.eval.base_client import InferenceClient
 
@@ -87,6 +88,28 @@ def test_begin_episode_is_part_of_the_core_contract():
     client = _Client()
     client.begin_episode(5)
     assert client._eval_episode_idx == 5
+
+
+def test_volo_cosmos3_keeps_backend_session_and_orchestrator_episode_ids():
+    client = VoloCosmos3Client.__new__(VoloCosmos3Client)
+    InferenceClient.__init__(client)
+    client._image_h = 2
+    client._image_w = 2
+    client.begin_episode(7)
+    extracted = {
+        "left_image": np.zeros((2, 2, 3), dtype=np.uint8),
+        "right_image": np.zeros((2, 2, 3), dtype=np.uint8),
+        "wrist_image": np.zeros((2, 2, 3), dtype=np.uint8),
+        "joint_position": np.zeros(7, dtype=np.float32),
+        "gripper_position": np.zeros(1, dtype=np.float32),
+        "session_id": "robolab-episode-7-env-3",
+        "_orchestrator_keys": {},
+    }
+
+    request = client._pack_request(extracted, "pick")
+
+    assert request["session_id"] == "robolab-episode-7-env-3"
+    assert request["__episode_id"] == 7
 
 
 def test_orchestrator_keys_are_optional():

--- a/tests/test_websocket_transport.py
+++ b/tests/test_websocket_transport.py
@@ -132,3 +132,34 @@ def test_transport_closes_connection_after_invalid_handshake(monkeypatch):
 
     assert ws.closed is True
     assert transport.connected is False
+
+
+def test_transport_rejects_structured_handshake_error(monkeypatch):
+    codec = MsgPackNumpy()
+    ws = _FakeWebSocket([codec.pack({"type": "error", "message": "policy disabled"})])
+    monkeypatch.setattr(websocket_transport.websockets.sync.client, "connect", lambda *_args, **_kwargs: ws)
+    transport = MsgPackWebSocketTransport("ws://localhost:8000")
+
+    with pytest.raises(RuntimeError, match="policy disabled"):
+        transport.connect()
+
+    assert ws.closed is True
+
+
+def test_transport_explains_close_before_handshake(monkeypatch):
+    class ClosedBeforeMetadata(Exception):
+        pass
+
+    class ClosingWebSocket(_FakeWebSocket):
+        def recv(self, timeout=None):
+            raise ClosedBeforeMetadata("closed")
+
+    ws = ClosingWebSocket([])
+    monkeypatch.setattr(websocket_transport.websockets.sync.client, "connect", lambda *_args, **_kwargs: ws)
+    monkeypatch.setattr("websockets.exceptions.ConnectionClosed", ClosedBeforeMetadata)
+    transport = MsgPackWebSocketTransport("ws://localhost:8000")
+
+    with pytest.raises(ConnectionError, match="closed before sending its metadata handshake"):
+        transport.connect()
+
+    assert ws.closed is True

--- a/tests/test_websocket_transport.py
+++ b/tests/test_websocket_transport.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from robolab.eval import websocket_transport
+from robolab.eval.websocket_transport import MsgPackNumpy, MsgPackWebSocketTransport
+
+
+class _FakeWebSocket:
+    def __init__(self, messages):
+        self.messages = list(messages)
+        self.sent = []
+        self.socket = object()
+        self.closed = False
+        self.recv_timeouts = []
+
+    def recv(self, timeout=None):
+        self.recv_timeouts.append(timeout)
+        return self.messages.pop(0)
+
+    def send(self, data):
+        self.sent.append(data)
+
+    def close(self):
+        self.closed = True
+        self.socket = None
+
+
+def test_msgpack_numpy_round_trip_and_writable_arrays():
+    codec = MsgPackNumpy()
+    payload = {
+        "array": np.arange(6, dtype=np.float32).reshape(2, 3)[:, ::-1],
+        "scalar": np.int64(7),
+    }
+
+    decoded = codec.unpack(codec.pack(payload))
+
+    np.testing.assert_array_equal(decoded["array"], payload["array"])
+    assert decoded["array"].flags.writeable is True
+    assert decoded["scalar"] == np.int64(7)
+
+
+def test_msgpack_numpy_rejects_unsupported_arrays():
+    codec = MsgPackNumpy()
+
+    with pytest.raises(ValueError, match="Unsupported dtype"):
+        codec.pack(np.asarray([object()], dtype=object))
+
+
+def test_transport_sends_bearer_header_consumes_handshake_and_decodes_response(monkeypatch):
+    codec = MsgPackNumpy()
+    action = np.asarray([[1.0, 2.0]], dtype=np.float32)
+    ws = _FakeWebSocket([codec.pack({"action_space": "joint_position"}), codec.pack(action)])
+    calls = []
+
+    def connect(uri, **kwargs):
+        calls.append((uri, kwargs))
+        return ws
+
+    monkeypatch.setattr(websocket_transport.websockets.sync.client, "connect", connect)
+    transport = MsgPackWebSocketTransport(
+        "wss://policy.example/v1/realtime/robot/openpi",
+        api_token="secret-token",
+        connect_kwargs={"open_timeout": 10, "ping_interval": 60},
+        metadata_timeout=20,
+    )
+
+    metadata = transport.connect()
+    response = transport.request({"prompt": "pick"}, timeout=30)
+
+    assert metadata == {"action_space": "joint_position"}
+    np.testing.assert_array_equal(response, action)
+    assert calls[0][0] == "wss://policy.example/v1/realtime/robot/openpi"
+    assert calls[0][1]["additional_headers"] == {"Authorization": "Bearer secret-token"}
+    assert calls[0][1]["compression"] is None
+    assert calls[0][1]["max_size"] is None
+    assert ws.recv_timeouts == [20, 30]
+    assert codec.unpack(ws.sent[0]) == {"prompt": "pick"}
+
+    transport.close()
+    assert ws.closed is True
+    assert transport.connected is False
+
+
+def test_transport_retries_without_ping_tuning_for_older_websockets(monkeypatch):
+    codec = MsgPackNumpy()
+    ws = _FakeWebSocket([codec.pack({})])
+    calls = []
+
+    def connect(_uri, **kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise TypeError("unsupported ping option")
+        return ws
+
+    monkeypatch.setattr(websocket_transport.websockets.sync.client, "connect", connect)
+    transport = MsgPackWebSocketTransport(
+        "ws://localhost:8000",
+        connect_kwargs={"ping_interval": 60, "ping_timeout": 600, "open_timeout": 300},
+    )
+
+    transport.connect()
+
+    assert calls[0]["ping_interval"] == 60
+    assert "ping_interval" not in calls[1]
+    assert "ping_timeout" not in calls[1]
+    assert calls[1]["open_timeout"] == 300
+
+
+def test_transport_rejects_text_inference_reply(monkeypatch):
+    codec = MsgPackNumpy()
+    ws = _FakeWebSocket([codec.pack({}), "server traceback"])
+    monkeypatch.setattr(websocket_transport.websockets.sync.client, "connect", lambda *_args, **_kwargs: ws)
+    transport = MsgPackWebSocketTransport("ws://localhost:8000")
+    transport.connect()
+
+    with pytest.raises(RuntimeError, match="server traceback"):
+        transport.request({"prompt": "pick"})
+
+
+def test_transport_closes_connection_after_invalid_handshake(monkeypatch):
+    ws = _FakeWebSocket(["authentication failed"])
+    monkeypatch.setattr(websocket_transport.websockets.sync.client, "connect", lambda *_args, **_kwargs: ws)
+    transport = MsgPackWebSocketTransport("ws://localhost:8000")
+
+    with pytest.raises(RuntimeError, match="authentication failed"):
+        transport.connect()
+
+    assert ws.closed is True
+    assert transport.connected is False


### PR DESCRIPTION
# Description

This PR adds a support for a RoboLab client in vllm-omni. We achieve this by:

1. Added `MsgPackWebSocketTransport` that handles metadata handshake and auth.
2. Added `remote-uri` and `remote-token` - first one is important for choosing the endpoint, second one is important for auth.
3. Correctly parsing the response

Additionally, did some refactoring of the DreamZero model to avoid duplication of the MsgPack code.

On vllm-omni side this PR also needs to be merged: https://github.com/vllm-project/vllm-omni/pull/6460

<!-- What does this PR do? For bug fixes, describe the problem and how to reproduce it. -->

## PR type

<!-- Check one. See CONTRIBUTING.md for what we accept in each category. -->

- [ ] New asset (object / scene / task / robot / variation)
- [ ] Bug fix
- [ ] New policy backend (`policies/<name>/`) — requires a paper/project reference and prior contact with the maintainers (see CONTRIBUTING.md)
- [ ] Documentation
- [x] Other (describe above)

## Checklist

- [x] All commits are signed off (`git commit -s`) — see [DCO](https://github.com/NVlabs/RoboLab/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] New Python files carry the standard SPDX header (`Apache-2.0`, NVIDIA copyright — copy from any existing file)
- [x] New assets are self-contained in their own folder, include their license, and are listed in `THIRD_PARTY_NOTICES.md`
- [x] Binary files (`.usd`, meshes, textures, images) are tracked with git-LFS
- [x] `uv run pytest tests/` passes locally
- [x] New robots: env configs compile against the benchmark tasks (see `docs/robots.md`)

## Asset attribution

<!-- For asset contributions: citation, contact information, and affiliation so we can credit your work. -->
