### PR TITLE
fix: align Galbot cameras and collisions

### DIFF
--- a/assets/robots/galbot_one_golf_description/usd/payloads/base.usda
+++ b/assets/robots/galbot_one_golf_description/usd/payloads/base.usda
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e32d3edcda5cd13d1493337c358ce157cf8e1a565fe5ee0084bffd2462a14dd0
-size 162650
+oid sha256:e8b875d66fbc490581e480766dc2f5d4ad223503031903e22050e5d9f6eeabbd
+size 159611

--- a/robolab/robots/galbot_golf.py
+++ b/robolab/robots/galbot_golf.py
@@ -14,9 +14,10 @@ from isaaclab.utils import configclass
 from robolab.constants import ROBOTS_DIR
 from robolab.robots.galbot_golf_definitions import *  # noqa
 
+GALBOT_GOLF_ASSET_DIR = os.path.join(ROBOTS_DIR, "galbot_one_golf_description")
 GALBOT_GOLF_USD_PATH = os.environ.get(
     "GALBOT_GOLF_USD_PATH",
-    os.path.join(ROBOTS_DIR, "galbot_one_golf_description", "usd", "galbot_one_golf.usda"),
+    os.path.join(GALBOT_GOLF_ASSET_DIR, "usd", "galbot_one_golf.usda"),
 )
 
 GALBOT_GOLF_USD_VARIANTS = {
@@ -115,16 +116,14 @@ _LEFT_EGO_CAM = TiledCameraCfg(
     width=640,
     data_types=["rgb"],
     spawn=sim_utils.PinholeCameraCfg(
-        focal_length=198.96716907989332 * 0.02,
-        focus_distance=0.0,
-        horizontal_aperture=640 * 0.02,
-        vertical_aperture=480 * 0.02,
-        clipping_range=(0.1, 15.0),
+        focal_length=0.488472287905,
+        horizontal_aperture=1.280137468212909,
+        vertical_aperture=0.9598969209810818,
+        clipping_range=(0.08, 15.0),
     ),
     offset=TiledCameraCfg.OffsetCfg(
-        pos=(0.082781626, -0.053015078, 0.031427263),
-        # golf_sensors.json stores xyzw; Isaac Lab expects wxyz.
-        rot=(0.698790116, -0.094725615, 0.702703943, 0.094480690),
+        pos=(0.07026692, -0.05334402, 0.02098859),
+        rot=(0.69873623, -0.09626416, 0.70197894, 0.09862283),
         convention="ros",
     ),
 )
@@ -142,8 +141,13 @@ def _galbot_golf_robot_cfg(
             usd_path=GALBOT_GOLF_USD_PATH,
             variants=GALBOT_GOLF_USD_VARIANTS,
             activate_contact_sensors=True,
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                max_depenetration_velocity=5.0,
+            ),
             articulation_props=sim_utils.ArticulationRootPropertiesCfg(
                 fix_root_link=True,
+                solver_position_iteration_count=128,
+                solver_velocity_iteration_count=4,
             ),
         ),
         init_state=ArticulationCfg.InitialStateCfg(
@@ -187,10 +191,10 @@ def _galbot_golf_robot_cfg(
             ),
             "grippers": ImplicitActuatorCfg(
                 joint_names_expr=["left_gripper_joint", "right_gripper_joint"],
-                effort_limit_sim=None,
-                velocity_limit_sim=None,
-                stiffness=None,
-                damping=None,
+                effort_limit_sim=1.0,
+                velocity_limit_sim=3.5,
+                stiffness=40.0,
+                damping=5.0,
             ),
             "wheels": ImplicitActuatorCfg(
                 joint_names_expr=WHEEL_JOINTS,

--- a/robolab/robots/galbot_golf_definitions.py
+++ b/robolab/robots/galbot_golf_definitions.py
@@ -50,28 +50,32 @@ GRIPPER_FINGER_LINK_LENGTH = 0.045
 GRIPPER_PAD_INSET = 0.0062
 
 GALBOT_GOLF_DEFAULT_JOINT_POS = {
-    "leg_joint1": 0.8,
-    "leg_joint2": 2.3,
-    "leg_joint3": 1.55,
+    # Coordinated linkage pose that pitches the torso 8 degrees toward the
+    # tabletop and lowers its mount by 15 cm without shifting it horizontally.
+    "leg_joint1": 0.3558,
+    "leg_joint2": 1.5059,
+    "leg_joint3": 1.3397,
     "leg_joint4": 0.0,
     "leg_joint5": 0.0,
     "head_joint1": 0.0,
-    "head_joint2": 0.36,
-    "left_arm_joint1": -0.1535,
-    "left_arm_joint2": -1.0087,
-    "left_arm_joint3": -0.0895,
-    "left_arm_joint4": -1.5743,
-    "left_arm_joint5": 0.2422,
-    "left_arm_joint6": -0.0009,
-    "left_arm_joint7": 0.9143,
+    "head_joint2": 0.48,
+    # Based on a valid Galbot training window whose wrist cameras both face
+    # the tabletop, with both end effectors lowered 8 cm for the RoboLab table.
+    "left_arm_joint1": 2.1164,
+    "left_arm_joint2": -1.3879,
+    "left_arm_joint3": -0.5284,
+    "left_arm_joint4": -1.7833,
+    "left_arm_joint5": -0.1364,
+    "left_arm_joint6": -0.8220,
+    "left_arm_joint7": -0.1354,
     "left_gripper_joint": GRIPPER_OPEN,
-    "right_arm_joint1": 0.1535,
-    "right_arm_joint2": 1.0087,
-    "right_arm_joint3": 0.0895,
-    "right_arm_joint4": 1.5743,
-    "right_arm_joint5": -0.2422,
-    "right_arm_joint6": -0.0009,
-    "right_arm_joint7": -0.9143,
+    "right_arm_joint1": -2.1079,
+    "right_arm_joint2": 1.1210,
+    "right_arm_joint3": 0.3646,
+    "right_arm_joint4": 1.8331,
+    "right_arm_joint5": 0.2758,
+    "right_arm_joint6": 0.7966,
+    "right_arm_joint7": -0.0235,
     "right_gripper_joint": GRIPPER_OPEN,
 }
 

--- a/tests/test_galbot_configs.py
+++ b/tests/test_galbot_configs.py
@@ -4,6 +4,7 @@
 """Focused contracts for the fixed-base Galbot One Golf embodiment."""
 
 import pytest
+from pxr import Usd
 
 from robolab.constants import TASK_DIR
 from robolab.core.environments.config import generate_scene_env_cfg
@@ -17,6 +18,7 @@ from robolab.core.environments.scene_fixture import (
 from robolab.core.task.task_utils import load_task_from_file, resolve_task_path
 from robolab.robots.droid import DroidCfg
 from robolab.robots.galbot_golf import (
+    GALBOT_GOLF_USD_PATH,
     GalbotGolfFixedBaseCfg,
     GalbotGolfFixedBaseDefaultPoseCfg,
     GalbotGolfLeftEgoCameraCfg,
@@ -53,19 +55,19 @@ def test_joint_actions_seed_uncommanded_targets_on_reset():
     assert whole_body.joint_names == BODY_JOINTS
 
 
-def test_left_ego_camera_uses_golf_sensor_calibration():
+def test_left_ego_camera_uses_policy_calibration():
     camera = GalbotGolfLeftEgoCameraCfg().left_ego_cam
     assert camera.prim_path.endswith("/robot/head_link2/head_end_effector_mount_link/camera_front_head_left_rgb")
-    assert camera.offset.pos == pytest.approx((0.082781626, -0.053015078, 0.031427263))
-    assert camera.offset.rot == pytest.approx((0.698790116, -0.094725615, 0.702703943, 0.094480690))
+    assert camera.offset.pos == pytest.approx((0.07026692, -0.05334402, 0.02098859))
+    assert camera.offset.rot == pytest.approx((0.69873623, -0.09626416, 0.70197894, 0.09862283))
     assert camera.offset.convention == "ros"
     assert (camera.width, camera.height) == (640, 480)
-    assert camera.spawn.clipping_range == pytest.approx((0.1, 15.0))
+    assert camera.spawn.clipping_range == pytest.approx((0.08, 15.0))
     assert camera.width * camera.spawn.focal_length / camera.spawn.horizontal_aperture == pytest.approx(
-        198.96716907989332
+        244.20991653
     )
     assert camera.height * camera.spawn.focal_length / camera.spawn.vertical_aperture == pytest.approx(
-        198.96716907989332
+        244.262371375
     )
 
 
@@ -78,6 +80,31 @@ def test_wrist_cameras_use_golf_sensor_calibration():
         assert camera.width * camera.spawn.focal_length / camera.spawn.horizontal_aperture == pytest.approx(202)
         assert camera.height * camera.spawn.focal_length / camera.spawn.vertical_aperture == pytest.approx(202)
         assert camera.spawn.clipping_range == pytest.approx((0.03, 10.0))
+
+
+def test_usd_contains_split_fingertip_collision_meshes():
+    assert GALBOT_GOLF_USD_PATH.endswith("galbot_one_golf.usda")
+    stage = Usd.Stage.Open(GALBOT_GOLF_USD_PATH, load=Usd.Stage.LoadAll)
+    root = stage.GetDefaultPrim()
+    physics_variant = root.GetVariantSets().GetVariantSet("Physics")
+    assert physics_variant.SetVariantSelection("physx")
+
+    finger_links = (
+        "left_gripper_l_finger_link",
+        "left_gripper_r_finger_link",
+        "right_gripper_l_finger_link",
+        "right_gripper_r_finger_link",
+    )
+    collision_meshes = (
+        ("link_3_collision_01", "mesh_71"),
+        ("link_3_collision_02", "mesh_72"),
+        ("link_3_collision_03", "mesh_73"),
+    )
+    for finger_link in finger_links:
+        for collision, mesh in collision_meshes:
+            prim = stage.GetPrimAtPath(f"/galbot_one_golf/{finger_link}/collisions/{collision}/{mesh}")
+            assert prim.IsDefined()
+            assert prim.IsActive()
 
 
 def test_tabletop_and_replay_root_frames_remain_separate():


### PR DESCRIPTION
# Description

This PR fixes camera alignment, reset-pose, and fingertip-contact issues in the fixed-base Galbot One Golf configuration.

### Head-camera framing

The previous simulated head-camera field of view and framing differed visibly from the Galbot training data. This PR updates the left head-camera pose, pinhole intrinsics, and clipping range to match the policy camera calibration. The wrist-camera configuration is unchanged.

| Original head camera | Updated head camera | Representative training frame |
| --- | --- | --- |
| ![Original head camera](https://github.com/user-attachments/assets/7d310921-9111-4442-8d05-c368513e65f2) | ![Updated head camera](https://github.com/user-attachments/assets/58c1e7fc-ef16-4492-bc87-c2c6666bf87b) | ![Training data](https://github.com/user-attachments/assets/11eda255-7562-41ce-8dc7-89d58424f412) |

### Fingertip collision geometry

The original `payloads/base.usda` used collision geometry generated by Isaac Sim's built-in convex-decomposition API, producing a single collision shape for each fingertip. In an Isaac Sim 6 beta release, this representation caused a collision issue that left a visible gap between the gripper and a lifted object.

This PR directly replaces `payloads/base.usda` with an updated asset in which our art team manually fitted three collision shapes to each fingertip. The existing top-level `galbot_one_golf.usda` remains the robot entry point. No overlay USD or alternate runtime asset path is introduced.

The replacement payload also removes the `/galbot_one_golf/holonomic_controller` OmniGraph (ROS 2 Twist to holonomic-controller nodes). RoboLab does not use this graph; Galbot control in RoboLab is performed through Isaac Lab articulation actions.

### Reset pose and contact stability

The updated fixed-base reset pose:

- pitches the torso approximately 8 degrees toward the tabletop and lowers its mount by approximately 15 cm;
- starts both arms from a valid Galbot training-window posture with the wrist cameras facing the tabletop;
- lowers both end effectors by 8 cm for the RoboLab table.

The robot configuration also:

- limits rigid-body depenetration velocity to 5 m/s;
- uses 128 position and 4 velocity solver iterations;
- configures the gripper actuator with a 1.0 N-m effort limit, 3.5 rad/s velocity limit, 40.0 stiffness, and 5.0 damping.

### Controlled replay

The following comparison uses the same recorded trajectory, initial state, and simulation seed in all three cases:

1. Original USD with original parameters
2. Updated USD with original parameters
3. Updated USD with tuned solver and gripper parameters

The replay was run with Isaac Sim 5.0.0 and Isaac Lab 2.2.0.

https://github.com/user-attachments/assets/c4195e14-c7d3-441e-9169-4e0fdde390fd

A small amount of table penetration can still occur because the G1 fingertip geometry is very sharp. Eliminating it completely would likely require softer gripper joint-control parameters rather than further collision-asset changes.

### Validation

- Opened the composed `galbot_one_golf.usda` stage with the `physx` variant selected and verified all 12 split fingertip collider prims are defined, active, carry `UsdPhysics.CollisionAPI`, and use `convexHull` approximation.
- Ran the focused collider regression test on an RTX 4090 environment:

```text
pytest -q tests/test_galbot_configs.py::test_usd_contains_split_fingertip_collision_meshes
. [100%]
```

- Confirmed the committed `payloads/base.usda` is the file resolved by the composed stage, with no Galbot asset symlink or `GALBOT_GOLF_USD_PATH` override involved.

## PR type

- [ ] New asset (object / scene / task / robot / variation)
- [x] Bug fix
- [ ] New policy backend (`policies/<name>/`) — requires a paper/project reference and prior contact with the maintainers (see CONTRIBUTING.md)
- [ ] Documentation
- [ ] Other (describe above)

## Checklist

- [x] All commits are signed off (`git commit -s`) — see [DCO](https://github.com/NVlabs/RoboLab/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] New Python files carry the standard SPDX header (no new Python files)
- [x] New assets are self-contained in their own folder, include their license, and are listed in `THIRD_PARTY_NOTICES.md` (no new third-party asset; this replaces the payload of the existing Galbot asset)
- [x] Binary files (`.usd`, meshes, textures, images) are tracked with git-LFS
- [ ] `uv run pytest tests/` passes locally (the focused Galbot collider test passes; the full suite was not run)
- [ ] New robots: env configs compile against the benchmark tasks (not applicable; this updates an existing robot)

## Asset attribution

The updated USD is a replacement version of the existing Galbot One Golf asset. The fingertip collision shapes were manually fitted by our art team. This PR adds no new external runtime dependency or alternate asset entry point.